### PR TITLE
Fix Trusty legacy non TLS build, undefined X509

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,39 +26,39 @@ script:
 
 jobs:
     include:
-        # - os: linux
-        #   dist: trusty
-        #   addons:   
-        #     apt:
-        #       update: true
-        #       packages:
-        #           - autoconf
-        #           - ocaml-nox
-        #           - camlidl
-        #           - coccinelle
-        #           - libocamlnet-ocaml-dev
-        #           - libocamlnet-ssl-ocaml
-        #           - libocamlnet-ssl-ocaml-dev
-        #           - libocamlnet-ocaml-bin
-        #           - libconfig-file-ocaml-dev
-        #           - camlp4
-        #           - libssl-dev
-        #           - libgnutls-dev
-        #           - ca-certificates
-        #           - pkg-config
-        #           - ocaml-findlib
-        #   before_script:
-        #         - wget http://download.camlcity.org/download/findlib-1.5.6.tar.gz -O /tmp/findlib-1.5.6.tar.gz
-        #         - cd /tmp && tar xzf findlib-1.5.6.tar.gz && cd findlib-1.5.6
-        #         - ./configure -config /etc/ocamlfind.conf -bindir /usr/bin/ -sitelib /usr/lib/ocaml -with-toolbox
-        #         - make all && make opt && sudo make install
-        #         - wget https://github.com/savonet/ocaml-ssl/releases/download/0.5.5/ocaml-ssl-0.5.5.tar.gz -O /tmp/ocaml-ssl-0.5.5.tar.gz
-        #         - cd /tmp && tar xzf /tmp/ocaml-ssl-0.5.5.tar.gz && cd ocaml-ssl-0.5.5 && ./configure && make && sudo make install
-        #         - cd $TRAVIS_BUILD_DIR
-        #   script:
-        #     - ./autogen.sh
-        #     - ./configure --with-idlgen --with-rpcgen --with-libnames=foo #--with-ssl --with-ssl-clientfiles='env'
-        #     - make
+        - os: linux
+          dist: trusty
+          addons:   
+            apt:
+              update: true
+              packages:
+                  - autoconf
+                  - ocaml-nox
+                  - camlidl
+                  - coccinelle
+                  - libocamlnet-ocaml-dev
+                  - libocamlnet-ssl-ocaml
+                  - libocamlnet-ssl-ocaml-dev
+                  - libocamlnet-ocaml-bin
+                  - libconfig-file-ocaml-dev
+                  - camlp4
+                  - libssl-dev
+                  - libgnutls-dev
+                  - ca-certificates
+                  - pkg-config
+                  - ocaml-findlib
+          before_script:
+                - wget http://download.camlcity.org/download/findlib-1.5.6.tar.gz -O /tmp/findlib-1.5.6.tar.gz
+                - cd /tmp && tar xzf findlib-1.5.6.tar.gz && cd findlib-1.5.6
+                - ./configure -config /etc/ocamlfind.conf -bindir /usr/bin/ -sitelib /usr/lib/ocaml -with-toolbox
+                - make all && make opt && sudo make install
+                - wget https://github.com/savonet/ocaml-ssl/releases/download/0.5.5/ocaml-ssl-0.5.5.tar.gz -O /tmp/ocaml-ssl-0.5.5.tar.gz
+                - cd /tmp && tar xzf /tmp/ocaml-ssl-0.5.5.tar.gz && cd ocaml-ssl-0.5.5 && ./configure && make && sudo make install
+                - cd $TRAVIS_BUILD_DIR
+          script:
+            - ./autogen.sh
+            - ./configure --with-idlgen --with-rpcgen --with-libnames=foo #--with-ssl --with-ssl-clientfiles='env'
+            - make
         - os: linux
           dist: xenial
         - os: linux

--- a/src/pkcs11proxyd/server_ssl.ml
+++ b/src/pkcs11proxyd/server_ssl.ml
@@ -146,6 +146,7 @@ let check_is_client_certificate_allowed allowed_clients_cert_path client_cert =
        Netplex_cenv.log `Err s;
        (false)
 
+IFDEF WITH_SSL THEN
 IFNDEF WITH_SSL_LEGACY THEN
 (* Stolen from OCamlnet Nettls *)
 let create_pem header_tag data =
@@ -183,6 +184,7 @@ let verify endpoint p_trust p_hostmatch =
   (* OCamlnet TLS module deals with name verification in the client case ...                           *)
   (* FIXME: add the '&& p_hostmatch' boolean in the return value when fixed in OCamlnet                *)
   (p_trust && (my_cert_check cert))
+ENDIF
 ENDIF
 
 IFDEF WITH_SSL THEN


### PR DESCRIPTION
I managed to fix legacy build without TLS but it seems we were importing a TLS symbol defined in Netplex >= 4.x irrespective of the IFDEF.

This makes the code compile without TLS at least.