### PR TITLE
Fix GCC10 compilation

### DIFF
--- a/src/bindings-pkcs11/Makefile.in
+++ b/src/bindings-pkcs11/Makefile.in
@@ -1,5 +1,5 @@
 CC=@CC@
-CFLAGS_OPT = -Wall -Wextra -pedantic -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -Wnested-externs -Winline -Wuninitialized
+CFLAGS_OPT = -Wall -Wextra -pedantic -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -Wnested-externs -Winline -Wuninitialized -fcommon
 CFLAGS_OPT += ${CPPFLAGS}
 CFLAGS = -O2 -fPIC $(CFLAGS_OPT) -I@OCAMLLIB@
 CFLAGS_DBG = -g -fPIC -I@OCAMLLIB@ $(CFLAGS_OPT)

--- a/src/client-lib/Makefile.in
+++ b/src/client-lib/Makefile.in
@@ -1,5 +1,5 @@
 CC = @CC@
-CFLAGS_OPT = -O2 -Wall -fPIC -Wextra -pedantic -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -Wnested-externs -Winline -Wuninitialized -fstack-protector-all
+CFLAGS_OPT = -O2 -Wall -fPIC -Wextra -pedantic -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Wmissing-prototypes -Wmissing-declarations -Wredundant-decls -Wnested-externs -Winline -Wuninitialized -fstack-protector-all -fcommon 
 CFLAGS_OPT += ${CPPFLAGS}
 LD_FLAGS = -lpthread @c_ssl_package@ @LDFLAGS@
 mem_prot_opt_caml=-ccopt -Wl,-z,relro,-z,now -ccopt -fstack-protector


### PR DESCRIPTION
GCC now enforces by default that global variables assigned in header files create a linker error.
Caml-Crush uses this in a lot of places, for now, we want keep the legacy behavior.