### PR TITLE
Implement string safety for compiling on OCaml > 4.10

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -292,16 +292,8 @@ esac
 AC_CHECK_LIB(pthread, pthread_mutex_init, THREAD_LIB="-lpthread",
                AC_MSG_ERROR(Cannot find pthread library.))
 
-# Handle the deprecated immutable String and adapt ocaml
-# compilation flag
-AX_COMPARE_VERSION([$OCAMLVERSION], [lt], [4.02.0], [use_unsafe_strings=no], [use_unsafe_strings=yes])
-if test "$use_unsafe_strings" == "yes"
-then
-	AC_SUBST(ocaml_options, "-unsafe-string")
-else
-	AC_SUBST(ocaml_options, "")
-fi
-
+AX_COMPARE_VERSION([$OCAMLVERSION], [lt], [4.02.0], AC_MSG_ERROR("OCaml versions older than 4.02 are not supported"))
+AC_SUBST(ocaml_options, "")
 
 # IDL generation handling
 ####

--- a/src/bindings-pkcs11/pkcs11.idl
+++ b/src/bindings-pkcs11/pkcs11.idl
@@ -3181,7 +3181,7 @@ quote(ml, "module Bytes = String");
 #endif
 quote(ml,
       "let char_array_to_string = fun a -> let s = Bytes.create (Array.length a) in\n");
-quote(ml, "  Array.iteri (fun i x -> Bytes.set s i x) a; s;;\n");
+quote(ml, "  Array.iteri (fun i x -> Bytes.set s i x) a; Bytes.to_string s;;\n");
 
 quote(ml,
       "let string_to_char_array = fun s -> Array.init (String.length s) (fun i -> s.[i]);;\n");
@@ -3262,7 +3262,7 @@ quote(ml, "          Bytes.set res !j tmp;");
 quote(ml, "          j := !j +1;");
 quote(ml, "          )");
 quote(ml, "     done;");
-quote(ml, "     (res);;");
+quote(ml, "     (Bytes.to_string res);;");
 
 quote(ml, "let sprint_hex_array myarray =");
 quote(ml, "  let s = Array.fold_left (");

--- a/src/bindings-pkcs11/pkcs11.idl
+++ b/src/bindings-pkcs11/pkcs11.idl
@@ -3175,10 +3175,6 @@ quote(mli, "val char_array_to_bool : char array -> nativeint\n");
 quote(mli, "val sprint_bool_attribute_value : nativeint -> string\n");
 quote(mli, "val sprint_template_array : ck_attribute array -> string\n");
 
-/* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module */
-#ifndef OCAML_WITH_BYTES_MODULE 
-quote(ml, "module Bytes = String");
-#endif
 quote(ml,
       "let char_array_to_string = fun a -> let s = Bytes.create (Array.length a) in\n");
 quote(ml, "  Array.iteri (fun i x -> Bytes.set s i x) a; Bytes.to_string s;;\n");

--- a/src/filter/filter/filter_actions_helpers/helpers_patch.ml
+++ b/src/filter/filter/filter_actions_helpers/helpers_patch.ml
@@ -469,24 +469,24 @@ let execute_external_command command data argvs env =
   let buffer_stderr = Buffer.create buffer_size in
   (* Append the argvs to the command *)
   let command = String.concat " " (List.concat [ [command]; Array.to_list argvs ]) in
-  let string = Bytes.create buffer_size in
+  let str_buffer = Bytes.create buffer_size in
   let (in_channel_stdout, out_channel, in_channel_stderr) = Unix.open_process_full command [||] in
   (* Write data to out_channel *)
-  output out_channel data 0 (String.length data);
+  output_string out_channel data;
   (* Close out_channel to tell it's over *)
   flush out_channel;
   close_out out_channel;
   (* Read result data on the in_channel stdout *)
   let chars_read_stdout = ref 1 in
   while !chars_read_stdout <> 0 do
-    chars_read_stdout := input in_channel_stdout string 0 buffer_size;
-    Buffer.add_substring buffer_stdout string 0 !chars_read_stdout
+    chars_read_stdout := input in_channel_stdout str_buffer 0 buffer_size;
+    Buffer.add_subbytes buffer_stdout str_buffer 0 !chars_read_stdout
   done;
   (* Command done, read stderr *)
   let chars_read_stderr = ref 1 in
   while !chars_read_stderr <> 0 do
-    chars_read_stderr := input in_channel_stderr string 0 buffer_size;
-    Buffer.add_substring buffer_stderr string 0 !chars_read_stderr
+    chars_read_stderr := input in_channel_stderr str_buffer 0 buffer_size;
+    Buffer.add_subbytes buffer_stderr str_buffer 0 !chars_read_stderr
   done;
   let ret_status = Unix.close_process_full (in_channel_stdout, out_channel, in_channel_stderr) in
   match ret_status with

--- a/src/filter/filter/filter_actions_helpers/helpers_patch.ml
+++ b/src/filter/filter/filter_actions_helpers/helpers_patch.ml
@@ -74,11 +74,6 @@
 
 ************************** MIT License HEADER ***********************************)
 
-(* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module *)
-IFNDEF OCAML_WITH_BYTES_MODULE THEN
-module Bytes = String
-ENDIF
-
 (* Global value to tell if we want to segregate usage *)
 let segregate_usage = ref false
 

--- a/src/filter/filter/filter_configuration.ml
+++ b/src/filter/filter/filter_configuration.ml
@@ -664,8 +664,7 @@ let print_some_help groupable_cp _ _ filename _ =
 let load_file f =
   let ic = open_in f in
   let n = in_channel_length ic in
-  let s = Bytes.create n in
-  really_input ic s 0 n;
+  let s = really_input_string ic n in
   close_in ic;
   (s)
 

--- a/src/filter/filter/filter_configuration.ml
+++ b/src/filter/filter/filter_configuration.ml
@@ -78,11 +78,6 @@ open Config_file
 open Filter_common
 open Filter_actions
 
-(* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module *)
-IFNDEF OCAML_WITH_BYTES_MODULE THEN
-module Bytes = String
-ENDIF
-
 let string_check_function a = match a with
   "C_LoadModule" -> a
 | "C_Initialize" -> a

--- a/src/pkcs11proxyd/server_ssl.ml
+++ b/src/pkcs11proxyd/server_ssl.ml
@@ -71,10 +71,6 @@
 
 ************************** MIT License HEADER *********************************)
 
-(* Use aliases if this is an old version (< 4.02) of OCaml without a Bytes module *)
-IFNDEF OCAML_WITH_BYTES_MODULE THEN
-module Bytes = String
-ENDIF
 
 IFDEF WITH_SSL THEN
 (* Reference those two variables here to avoid circulare dependencies *)

--- a/src/pkcs11proxyd/server_ssl.ml
+++ b/src/pkcs11proxyd/server_ssl.ml
@@ -89,8 +89,7 @@ ENDIF
 let read_file f =
   let ic = open_in f in
   let n = in_channel_length ic in
-  let s = Bytes.create n in
-  really_input ic s 0 n;
+  let s = really_input_string ic n in
   close_in ic;
   (s)
 


### PR DESCRIPTION
Hi,

I've written these patches to fix the build on recent default OCaml builds. Note that I'm not particularly fluent in OCaml nor am I very familiar with the various tools, including IDL.

I'm fairly confident that the first commit is usable as-is, but the second one is up for debate as it changes the supported versions as the `#ifndef OCAML_WITH_BYTES_MODULE` statement appears not to work. I'd love for a better alternative though, hence the split in two commits.

Regardless, I plan on proposing those two commits as patches in the Debian and Ubuntu packages to fix the builds there, as the support for older versions isn't really a problem in this context.