### PR TITLE
Fix compilation on OpenSSL 3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
            flavor: "bullseye"
          - dist: "debian"
            flavor: "buster"
-        - dist: "ubuntu"
+         - dist: "ubuntu"
            flavor: "jammy"
         #  Ubuntu Focal does not have coccinelle package, skip for now
         #  - dist: "ubuntu"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
            flavor: "bullseye"
          - dist: "debian"
            flavor: "buster"
+        - dist: "ubuntu"
+           flavor: "jammy"
         #  Ubuntu Focal does not have coccinelle package, skip for now
         #  - dist: "ubuntu"
         #    flavor: "focal"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ jobs:
         name: Trusty
         script: docker build -t caml-crush-trusty -f Dockerfile.ubuntu-trusty .
       -  
+        name: Jammy
+        script: docker build -t caml-crush-jammy --build-arg dist=ubuntu --build-arg flavor=jammy -f Dockerfile.debian .
+      -  
         name: Xenial
         script: docker build -t caml-crush-xenial --build-arg dist=ubuntu --build-arg flavor=xenial -f Dockerfile.debian .
       -  

--- a/autogen.sh
+++ b/autogen.sh
@@ -9,6 +9,7 @@ then
   autoconf configure-win32.ac > configure
 else
   cp Makefile.Unix.in Makefile.in
+  autoupdate
   autoconf configure.ac > configure
 fi
 echo "  |-> Run ./configure with the desired options, and then make"

--- a/configure.ac
+++ b/configure.ac
@@ -669,12 +669,25 @@ then
 			# Check the library
 			AC_CHECK_LIB(ssl, SSL_read, OPENSSL_LIB="-lssl",
                			AC_MSG_ERROR(Cannot find symbol in openssl library.))
+			# Check if we are in presence of openssl >= 3.0.0 or not
+			#AC_CHECK_LIB(ssl, OSSL_PROVIDER_load, OPENSSL_LIB="-lssl", openssl_3_0_0=no)
+      AC_MSG_CHECKING([if dealing with OpenSSL 3])
+      AC_TRY_COMPILE(
+        [#include <openssl/opensslv.h>],
+        [
+        #if OPENSSL_VERSION_MAJOR != 3
+        #error OpenSSL version is too old ...
+        #endif
+        ],
+      [AC_MSG_RESULT([yes]); openssl_3_0_0=yes],
+      [AC_MSG_RESULT([no]); openssl_3_0_0=no]
+      )
 			# Check if we are in presence of openssl >= 1.1.0 or not
-			AC_CHECK_LIB(ssl, OPENSSL_init_ssl, OPENSSL_LIB="-lssl", new_openssl=no)
+			AC_CHECK_LIB(ssl, OPENSSL_init_ssl, OPENSSL_LIB="-lssl", openssl_1_1_0=no)
 			# Check for used symbols
 			AC_CHECK_LIB(ssl, SSL_write, OPENSSL_LIB="-lssl",
                			AC_MSG_ERROR(Cannot find symbol in openssl library.))
-			if test "$new_openssl" == "no"; then
+			if test "$openssl_1_1_0" == "no"; then
 				AC_MSG_NOTICE([Openssl < 1.1.0 detected])
 				# SSL_load_error_strings is deprecated in openssl >= 1.1.0
 				AC_CHECK_LIB(ssl, SSL_load_error_strings, OPENSSL_LIB="-lssl",
@@ -683,8 +696,12 @@ then
 				AC_CHECK_LIB(ssl, SSL_library_init, OPENSSL_LIB="-lssl",
 					AC_MSG_ERROR(Cannot find symbol in openssl library.))
 			else
-				AC_MSG_NOTICE([Openssl >= 1.1.0 detected])
-				AC_CHECK_LIB(ssl, OPENSSL_init_ssl, OPENSSL_LIB="-lssl",
+			  if test "$openssl_3_0_0" == "no"; then
+			    AC_MSG_NOTICE([Openssl >= 1.1.0 detected])
+			  else
+			    AC_MSG_NOTICE([Openssl >= 3.0.0 detected])
+			  fi
+			  AC_CHECK_LIB(ssl, OPENSSL_init_ssl, OPENSSL_LIB="-lssl",
 					AC_MSG_ERROR(Cannot find symbol in openssl library.))
 			fi
 			AC_CHECK_LIB(ssl, SSL_CTX_new, OPENSSL_LIB="-lssl",
@@ -705,8 +722,13 @@ then
                			AC_MSG_ERROR(Cannot find symbol in openssl library.))
 			AC_CHECK_LIB(ssl, SSL_connect, OPENSSL_LIB="-lssl",
                			AC_MSG_ERROR(Cannot find symbol in openssl library.))
-			AC_CHECK_LIB(ssl, SSL_get_peer_certificate, OPENSSL_LIB="-lssl",
-               			AC_MSG_ERROR(Cannot find symbol in openssl library.))
+			if test "$openssl_3_0_0" == "no"; then
+			  AC_CHECK_LIB(ssl, SSL_get_peer_certificate, OPENSSL_LIB="-lssl",
+                 			AC_MSG_ERROR(Cannot find symbol in openssl library.))
+			else
+			  AC_CHECK_LIB(ssl, SSL_get1_peer_certificate, OPENSSL_LIB="-lssl",
+                 			AC_MSG_ERROR(Cannot find symbol in openssl library.))
+			fi
 			AC_CHECK_LIB(ssl, SSL_get_verify_result, OPENSSL_LIB="-lssl",
                			AC_MSG_ERROR(Cannot find symbol in openssl library.))
 			AC_CHECK_LIB(ssl, SSL_shutdown, OPENSSL_LIB="-lssl",

--- a/src/client-lib/modwrap.h
+++ b/src/client-lib/modwrap.h
@@ -409,6 +409,10 @@ int start_openssl(int sock);
 int purge_openssl(void);
 SSL_CTX *ctx;
 SSL *ssl;
+// OpenSSL 3
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(SSL_get_peer_certificate))
+#define SSL_get_peer_certificate(s) SSL_get1_peer_certificate(s)
+#endif
 #endif
 
 /* Environment variable holding the socket path to override */

--- a/src/client-lib/modwrap_crpc_ssl.c
+++ b/src/client-lib/modwrap_crpc_ssl.c
@@ -726,7 +726,10 @@ int start_openssl(int sock)
 #else
   OPENSSL_init_ssl(0, NULL);
 #endif
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+  /* Deprecated in openssl >= 3.0.0 */
   ERR_load_BIO_strings();
+#endif
   OpenSSL_add_all_algorithms();
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L


### PR DESCRIPTION
As reported in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=990363 Caml Crush used not to build against OpenSSL 3, mainly because of some function being renamed.

I've added detection logic to the `configure.ac` and also ported some define logic to handle deprecation.

Thanks to @locutusofborg for email/reporting/fixing in Ubuntu.
